### PR TITLE
Replace Deprecated `slack/client` package with `slack/web-api` new package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,74 +78,34 @@
         }
       }
     },
-    "@slack/client": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@slack/client/-/client-5.0.2.tgz",
-      "integrity": "sha512-HurKTUBZlwj/1cnZ6QOHpYR7k+G62WlL+13DgYD7onVRnQWggkIyCg+ymX1kQn6txzNdUyDEaixyCvBvmhH8tQ==",
-      "requires": {
-        "@slack/logger": "^1.0.0",
-        "@slack/rtm-api": "^5.0.2",
-        "@slack/types": "^1.1.0",
-        "@slack/web-api": "^5.1.0",
-        "@slack/webhook": "^5.0.1"
-      }
-    },
     "@slack/logger": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-1.1.1.tgz",
-      "integrity": "sha512-PAC5CMnNAv/FPtJ0le+YD2wUV+tZ7n3Bnjj9dBI+deIcHsExCnQkQmZE79cLvfuYXbz3PWyv5coti30MJQhEjA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-2.0.0.tgz",
+      "integrity": "sha512-OkIJpiU2fz6HOJujhlhfIGrc8hB4ibqtf7nnbJQDerG0BqwZCfmgtK5sWzZ0TkXVRBKD5MpLrTmCYyMxoMCgPw==",
       "requires": {
         "@types/node": ">=8.9.0"
       }
     },
-    "@slack/rtm-api": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@slack/rtm-api/-/rtm-api-5.0.5.tgz",
-      "integrity": "sha512-x2B4hyoxjg62cxf4M5QRomx+xYp2XoajPKdd24SM2Sl4m+IrzwKzmcrysQuYmF6BMsm3IoTKymW5BBGckHGTIw==",
-      "requires": {
-        "@slack/logger": ">=1.0.0 <3.0.0",
-        "@slack/web-api": "^5.3.0",
-        "@types/node": ">=8.9.0",
-        "@types/p-queue": "^2.3.2",
-        "@types/ws": "^7.2.5",
-        "eventemitter3": "^3.1.0",
-        "finity": "^0.5.4",
-        "p-cancelable": "^1.1.0",
-        "p-queue": "^2.4.2",
-        "ws": "^5.2.0"
-      }
-    },
     "@slack/types": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.9.0.tgz",
-      "integrity": "sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
+      "integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
     },
     "@slack/web-api": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.12.0.tgz",
-      "integrity": "sha512-ygSnNHVid7PltGo7W36f2SNVHyliemkzxn9uSwgnWNF7CHmWBKWAylU/eoDml9l5K7akMOxbousiurOw4XqOFg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.13.0.tgz",
+      "integrity": "sha512-xT27bhYvkjidKCmGt3Dy4tx12Hk4oI9G/6vQFUdDXV1WSk50tysswHe67ckgcSU95yRPcnLVQicVpM3cAH6/AA==",
       "requires": {
         "@slack/logger": ">=1.0.0 <3.0.0",
         "@slack/types": "^1.7.0",
         "@types/is-stream": "^1.1.0",
         "@types/node": ">=8.9.0",
-        "@types/p-queue": "^2.3.2",
         "axios": "^0.19.0",
         "eventemitter3": "^3.1.0",
         "form-data": "^2.5.0",
         "is-stream": "^1.1.0",
-        "p-queue": "^2.4.2",
+        "p-queue": "^6.6.1",
         "p-retry": "^4.0.0"
-      }
-    },
-    "@slack/webhook": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@slack/webhook/-/webhook-5.0.3.tgz",
-      "integrity": "sha512-51vnejJ2zABNumPVukOLyerpHQT39/Lt0TYFtOEz/N2X77bPofOgfPj2atB3etaM07mxWHLT9IRJ4Zuqx38DkQ==",
-      "requires": {
-        "@slack/types": "^1.2.1",
-        "@types/node": ">=8.9.0",
-        "axios": "^0.19.0"
       }
     },
     "@types/is-stream": {
@@ -157,27 +117,14 @@
       }
     },
     "@types/node": {
-      "version": "14.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
-    },
-    "@types/p-queue": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
-      "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
     },
     "@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
-    },
-    "@types/ws": {
-      "version": "7.2.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.7.tgz",
-      "integrity": "sha512-UUFC/xxqFLP17hTva8/lVT0SybLUrfSD9c+iapKb0fEiC8uoDbA+xuZ3pAN603eW+bY8ebSMLm9jXdIPnD0ZgA==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "acorn": {
       "version": "7.4.1",
@@ -238,11 +185,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async-limiter": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
-      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -622,11 +564,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "finity": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/finity/-/finity-0.5.4.tgz",
-      "integrity": "sha512-3l+5/1tuw616Lgb0QBimxfdd2TqaDGpfCBpfX6EqtFmqUV3FtQnVEX4Aa62DagYEqnsTIjZcTfbq9msDbXYgyA=="
-    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -902,15 +839,26 @@
         "word-wrap": "^1.2.3"
       }
     },
-    "p-cancelable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
-      "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-queue": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
-      "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "requires": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.7",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+          "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+        }
+      }
     },
     "p-retry": {
       "version": "4.2.0",
@@ -919,6 +867,14 @@
       "requires": {
         "@types/retry": "^0.12.0",
         "retry": "^0.12.0"
+      }
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
       }
     },
     "parent-module": {
@@ -1152,14 +1108,6 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
-      }
-    },
-    "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "requires": {
-        "async-limiter": "~1.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/rogerluan/app-store-connect-notifier#readme",
   "dependencies": {
-    "@slack/client": "5.0.2",
+    "@slack/web-api": "5.13.0",
     "dirty": "^1.1.0",
     "moment": "^2.29.1"
   },

--- a/src/post-update.js
+++ b/src/post-update.js
@@ -2,40 +2,35 @@ const moment = require("moment")
 require("./string-utilities.js")
 
 function postToSlack(appInfo, submissionStartDate) {
-    const WebClient = require("@slack/client").WebClient
-    const client = new WebClient(process.env.BOT_API_TOKEN)
     const message = `The status of your app *${appInfo.name}* has been changed to *${appInfo.status.formatted()}*`
     const attachment = slackAttachment(appInfo, submissionStartDate)
-    const params = {
-        "attachments" : [attachment],
-        "as_user" : "true"
-    }
-    var channel = process.env.SLACK_CHANNEL_NAME
-    if (!channel) {
-        channel = "#ios-app-updates"
-    }
-    client.chat.postMessage(channel, message, params, function(err,) {
-        if (err) {
-            console.log("Error:", err)
-        }
-    })
+    const channel = process.env.SLACK_CHANNEL_NAME ?? "#ios-app-updates"
+    post(message, channel, [attachment])
 }
 
 function postMessageToSlack(message) {
-    const WebClient = require("@slack/client").WebClient
-    const client = new WebClient(process.env.BOT_API_TOKEN)
-    const params = {
-        "as_user" : "true"
-    }
     const channel = process.env.BOT_STATUS_SLACK_CHANNEL_NAME
     if (!channel) {
         return
     }
-    client.chat.postMessage(channel, message, params, function(err,) {
-        if (err) {
-            console.log("Error:", err)
-        }
-    })
+    post(message, channel, null)
+}
+
+function post(message, channel, attachments) {
+    const { WebClient } = require("@slack/web-api")
+    const client = new WebClient(process.env.BOT_API_TOKEN)
+    const request = async() => {
+        // Post a message to the channel, and await the result.
+        // Find more arguments and details of the response: https://api.slack.com/methods/chat.postMessage
+        const result = await client.chat.postMessage({
+            text: message,
+            channel: channel,
+            attachments: attachments,
+            as_user: true,
+        })
+        console.log(`Successfully sent message ${result.ts} in conversation ${channel}`)
+    }
+    request()
 }
 
 function slackAttachment(appInfo, submissionStartDate) {


### PR DESCRIPTION
This PR fixes a Slack posting issue caused by https://github.com/rogerluan/app-store-connect-notifier/pull/25
I realized that `slack/client` was marked as deprecated by Slack so I replaced it with the `slack/web-api` as they suggest.