### PR TITLE
Clean up spaceship logs older than 7 days

### DIFF
--- a/src/poll-itc.js
+++ b/src/poll-itc.js
@@ -31,6 +31,8 @@ function checkAppStatus() {
             console.log(stderr)
         }
     })
+
+    exec("find /tmp/ -maxdepth 1 -name 'spaceship*.log' -mtime +7 -delete")
 }
 
 function _checkAppStatus(currentAppInfo) {


### PR DESCRIPTION
I discovered I had 100GB of logs in /tmp
Unfortunately spaceship doesn't have a nice way of turning this off from what I found https://github.com/fastlane/fastlane/issues/12854
