### PR TITLE
Update Dockerfile to use ruby 3.1, readme fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM timbru31/ruby-node:2.6-14
+FROM timbru31/ruby-node:3.1
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ services:
     hostname: app-store-connect-notifier
     image: rogerluan/app-store-connect-notifier
     environment:
-      SPACESHIP_CONNECT_API_KEY: >
+      SPACESHIP_CONNECT_API_KEY: |
         -----BEGIN PRIVATE KEY-----
         xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
         xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx


### PR DESCRIPTION
Right now `docker build` command is failing due to ruby version mismatch:

```
➜  app-store-connect-notifier git:(master) docker build -t rogerluan/app-store-connect-notifier .
[+] Building 62.6s (9/12)
 => [internal] load build definition from Dockerfile                                                                                                                               0.0s
 => => transferring dockerfile: 259B                                                                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/timbru31/ruby-node:2.6-14                                                                                                               3.0s
 => [1/8] FROM docker.io/timbru31/ruby-node:2.6-14@sha256:8b8211fe5c823934e2e0a6091e9e9e1d3e8a0aa2c3d8cf4c1f854b57973dd942                                                        43.8s
 => => resolve docker.io/timbru31/ruby-node:2.6-14@sha256:8b8211fe5c823934e2e0a6091e9e9e1d3e8a0aa2c3d8cf4c1f854b57973dd942                                                         0.0s
 => => sha256:83d5dcfea08e6927083bc886bf182fc39d87bb04b54b63002ac0c4c0b9aab682 53.63MB / 53.63MB                                                                                   7.6s
 => => sha256:8b8211fe5c823934e2e0a6091e9e9e1d3e8a0aa2c3d8cf4c1f854b57973dd942 1.08kB / 1.08kB                                                                                     0.0s
 => => sha256:e83b9319f365a5518cb0f28dc75109f66461d534054cf9bc604e7ebde616b290 7.71kB / 7.71kB                                                                                     0.0s
 => => sha256:5c79b19335f27cc78840bf9159e875322f3252ac06113c73756f9d4fba905f9b 10.66MB / 10.66MB                                                                                   5.2s
 => => sha256:01340716c459bc34196f788919c32e315a2fd47e8d924b1d81ece416017749f0 2.21kB / 2.21kB                                                                                     0.0s
 => => sha256:45cfa86b7b1aca6d694057e4d42ee1440527f41c00b9e577df729244380c9eba 4.94MB / 4.94MB                                                                                     3.6s
 => => sha256:350ecaf08eac09037b05465ab97a1b8f7bc9b7a9b1fcef900dedd7dba9bbcf4d 54.67MB / 54.67MB                                                                                  22.7s
 => => sha256:360771a6f68b528d0cf1b5534f58aaff178b78ec0fafb483b1ef47b7ae2b2d3e 189.58MB / 189.58MB                                                                                35.5s
 => => sha256:20bcd92980bebe2ffb03adad29deaed5a9f4b5c001d3921dc97cee425b49fba8 197B / 197B                                                                                         7.9s
 => => extracting sha256:83d5dcfea08e6927083bc886bf182fc39d87bb04b54b63002ac0c4c0b9aab682                                                                                          1.8s
 => => sha256:7f1482573a933899d5043e8d39c3cb12500ac439a48f0212393534a97876533c 21.24MB / 21.24MB                                                                                  12.4s
 => => extracting sha256:45cfa86b7b1aca6d694057e4d42ee1440527f41c00b9e577df729244380c9eba                                                                                          0.2s
 => => extracting sha256:5c79b19335f27cc78840bf9159e875322f3252ac06113c73756f9d4fba905f9b                                                                                          0.2s
 => => sha256:c7d7d2b0100184acfef5571fe454011c404ce3f25e8e116fb599ff600d879581 142B / 142B                                                                                        12.7s
 => => sha256:719be161942c6c8489f085d717d5bdd9212eb25640e9a5c2618bd1cc631d96a9 45.35MB / 45.35MB                                                                                  21.8s
 => => extracting sha256:350ecaf08eac09037b05465ab97a1b8f7bc9b7a9b1fcef900dedd7dba9bbcf4d                                                                                          2.2s
 => => extracting sha256:360771a6f68b528d0cf1b5534f58aaff178b78ec0fafb483b1ef47b7ae2b2d3e                                                                                          5.7s
 => => extracting sha256:20bcd92980bebe2ffb03adad29deaed5a9f4b5c001d3921dc97cee425b49fba8                                                                                          0.0s
 => => extracting sha256:7f1482573a933899d5043e8d39c3cb12500ac439a48f0212393534a97876533c                                                                                          0.5s
 => => extracting sha256:c7d7d2b0100184acfef5571fe454011c404ce3f25e8e116fb599ff600d879581                                                                                          0.0s
 => => extracting sha256:719be161942c6c8489f085d717d5bdd9212eb25640e9a5c2618bd1cc631d96a9                                                                                          1.7s
 => [internal] load build context                                                                                                                                                  0.1s
 => => transferring context: 1.31MB                                                                                                                                                0.1s
 => [2/8] WORKDIR /app                                                                                                                                                             0.5s
 => [3/8] RUN gem update bundler                                                                                                                                                  14.8s
 => [4/8] COPY Gemfile Gemfile.lock /app/                                                                                                                                          0.0s
 => ERROR [5/8] RUN bundle install                                                                                                                                                 0.4s
------
 > [5/8] RUN bundle install:
#8 0.260 Your RubyGems version (3.0.3.1) has a bug that prevents `required_ruby_version` from working for Bundler. Any scripts that use `gem install bundler` will break as soon as Bundler drops support for your Ruby version. Please upgrade RubyGems to avoid future breakage and silence this warning by running `gem update --system 3.2.3`
#8 0.355 Your Ruby version is 2.6.10, but your Gemfile specified ~> 3.1
------
executor failed running [/bin/bash -o pipefail -c bundle install]: exit code: 18
```

Also update readme example, pass api key via yaml multiline syntax without newlines, currently the following error is shown:

```
spaceship/lib/spaceship/connect_api/token.rb:71:in `initialize': invalid curve name (OpenSSL::PKey::ECError)
```